### PR TITLE
No newline in libdir

### DIFF
--- a/kni/manifest.xml
+++ b/kni/manifest.xml
@@ -13,8 +13,7 @@
   <review status="unreviewed" notes=""/>
   <url>http://ros.org/wiki/kni</url>
   <export>
-    <cpp cflags="-I${prefix}/KNI_4.3.0/include" lflags="-Wl,-rpath,${prefix}/KNI_4.3.0/lib/linux -L${prefix}/KNI_4.3.0/lib/linux
-     -lKNIBase -lKinematics -lKNI_InvKin -lKNI_LM"/>
+    <cpp cflags="-I${prefix}/KNI_4.3.0/include" lflags="-Wl,-rpath,${prefix}/KNI_4.3.0/lib/linux -L${prefix}/KNI_4.3.0/lib/linux -lKNIBase -lKinematics -lKNI_InvKin -lKNI_LM"/>
   </export>
 </package>
 


### PR DESCRIPTION
katana failed over here because cmake/rosbuild/... included the trailing
\n in the manifest in the libdir. In effect, cmake detects a syntax error in
its cache file.
