### PR TITLE
kni: Fix deprecation warning

### DIFF
--- a/kni/KNI_4.3.0/lib/kinematics/roboop/source/gnugraph.cpp
+++ b/kni/KNI_4.3.0/lib/kinematics/roboop/source/gnugraph.cpp
@@ -78,7 +78,7 @@ static const char rcsid[] = "$Id: gnugraph.cpp,v 1.44 2006/05/19 17:49:58 gourde
 using namespace std;
 
 
-char *curvetype[] =
+const char *curvetype[] =
    {"lines",
     "points",
     "linespoints",


### PR DESCRIPTION
This fixes the following warning:

    warning: deprecated conversion from string constant to 'char*'